### PR TITLE
HTTP requests are rejected when Gladys uses HTTPS

### DIFF
--- a/lib/createDevice.js
+++ b/lib/createDevice.js
@@ -6,7 +6,8 @@ module.exports = function createDevice(device){
         method: 'POST',
         uri: config.gladysUrl + '/device?token=' + config.token,
         body: device,
-        json: true
+        json: true,
+	rejectUnauthorized: false
     };
 
     return rp(options);

--- a/lib/createDeviceState.js
+++ b/lib/createDeviceState.js
@@ -6,7 +6,8 @@ module.exports = function createDevice(deviceTypeId, value){
         method: 'POST',
         uri: config.gladysUrl + '/devicestate?token=' + config.token,
         body: {devicetype: deviceTypeId, value: value},
-        json: true
+        json: true,
+	rejectUnauthorized: false
     };
 
     return rp(options);


### PR DESCRIPTION
When HTTPS is enabled in Gladys the TLS certificate is self-signed. I just added the option to avoid rejecting  self-signed certificates when making a request.